### PR TITLE
chore(logstash-version): Upgrade dependencies to be compatible with Logstash 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - jruby-9.0.5.0
+  - jruby-1.7.25
+jdk: oraclejdk8
 env:
   JRUBY_OPTS="--debug"
 script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-#ruby=jruby-9.0.5.0
+#ruby=jruby-1.7.25
 source 'https://rubygems.org'
 gemspec

--- a/logstash-codec-bytes.gemspec
+++ b/logstash-codec-bytes.gemspec
@@ -15,9 +15,8 @@ Gem::Specification.new do |s|
 
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "codec" }
 
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
 
   s.add_development_dependency "logstash-devutils"
-  s.add_development_dependency "coveralls", "~> 0.8.1"
   s.add_development_dependency "simplecov"
 end

--- a/spec/codecs/bytes_spec.rb
+++ b/spec/codecs/bytes_spec.rb
@@ -11,14 +11,14 @@ describe LogStash::Codecs::Bytes do
     data = "TestTest"
 
     subject.decode(data) do |event|
-      expect(event["message"].length).to eq(subject.length)
+      expect(event.get("message").length).to eq(subject.length)
     end
 
   end
 
   it "creates an event for each complete chunk" do
     data = "TestTes"
-    expected_count = data.bytes.length / subject.length
+    expected_count = data.bytes.count / subject.length
     count = 0
 
     subject.decode(data) { count += 1 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,5 @@
 require 'simplecov'
-require 'coveralls'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]
 SimpleCov.minimum_coverage 100
 SimpleCov.start
 


### PR DESCRIPTION
**What & Why**

Upgrade the plugin to work with Logstash 5.0, because we will be migrating to Logstash 5.0